### PR TITLE
+ reduce memory use in binary GET

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -222,37 +222,38 @@ public  abstract class OperationImpl extends BaseOperationImpl
    */
   protected OperationStatus getStatusForErrorCode(int errCode, byte[] errPl)
     throws IOException {
-    errorMsg = new byte[errPl.length];
-    errorMsg = errPl.clone();
 
-    StatusCode statusCode = StatusCode.fromBinaryCode(errCode);
+    if(errCode == SUCCESS) {
+        return STATUS_OK;
+    } else {
+        StatusCode statusCode = StatusCode.fromBinaryCode(errCode);
+        errorMsg = errPl.clone();
 
-    switch (errCode) {
-    case SUCCESS:
-      return STATUS_OK;
-    case ERR_NOT_FOUND:
-      return new CASOperationStatus(false, new String(errPl),
-          CASResponse.NOT_FOUND, statusCode);
-    case ERR_EXISTS:
-      return new CASOperationStatus(false, new String(errPl),
-          CASResponse.EXISTS, statusCode);
-    case ERR_NOT_STORED:
-      return new CASOperationStatus(false, new String(errPl),
-          CASResponse.NOT_FOUND, statusCode);
-    case ERR_2BIG:
-    case ERR_INTERNAL:
-      handleError(OperationErrorType.SERVER, new String(errPl));
-    case ERR_INVAL:
-    case ERR_DELTA_BADVAL:
-    case ERR_NOT_MY_VBUCKET:
-    case ERR_UNKNOWN_COMMAND:
-    case ERR_NO_MEM:
-    case ERR_NOT_SUPPORTED:
-    case ERR_BUSY:
-    case ERR_TEMP_FAIL:
-      return new OperationStatus(false, new String(errPl), statusCode);
-    default:
-      return null;
+        switch (errCode) {
+            case ERR_NOT_FOUND:
+                return new CASOperationStatus(false, new String(errPl),
+                        CASResponse.NOT_FOUND, statusCode);
+            case ERR_EXISTS:
+                return new CASOperationStatus(false, new String(errPl),
+                        CASResponse.EXISTS, statusCode);
+            case ERR_NOT_STORED:
+                return new CASOperationStatus(false, new String(errPl),
+                        CASResponse.NOT_FOUND, statusCode);
+            case ERR_2BIG:
+            case ERR_INTERNAL:
+                handleError(OperationErrorType.SERVER, new String(errPl));
+            case ERR_INVAL:
+            case ERR_DELTA_BADVAL:
+            case ERR_NOT_MY_VBUCKET:
+            case ERR_UNKNOWN_COMMAND:
+            case ERR_NO_MEM:
+            case ERR_NOT_SUPPORTED:
+            case ERR_BUSY:
+            case ERR_TEMP_FAIL:
+                return new OperationStatus(false, new String(errPl), statusCode);
+            default:
+                return null;
+        }
     }
   }
 


### PR DESCRIPTION
Hi,

I noticed that a byte[] array of the size of the content fetched from memcached is created for every GET that is successful, in order to represent a errorMsg. This results in a lot of memory allocations, that are subsequently not used.

This PR (which I originally opened against dustin/java-memcached-client) removes the byte[] allocation in the SUCCESS scenario, removing allocation pressure. The below screen shots are from a JMC view of a flight recorder profile showing the removal of GB's of allocations from a load test that simulates 760,000 gets for 26k of content stored in memcached. Removing the allocations, allowed another 70k of requests to be generated by the load test.

Apologies if the two repositories are the one in the same thing, and for the duplicate pull requests, I'm not sure which git repo own the publishing of the maven artifact (http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22net.spy%22%20AND%20a%3A%22spymemcached%22)

BEFORE
![screen shot 2014-05-25 at 13 17 19](https://cloud.githubusercontent.com/assets/211070/3101298/cbe2bac2-e630-11e3-959d-5d7d0097e2b8.png)

AFTER
![screen shot 2014-05-25 at 14 05 23](https://cloud.githubusercontent.com/assets/211070/3101299/d623eaec-e630-11e3-8030-11c51507777a.png)

cheers
/dom
