### PR TITLE
Fixed bug in max reconnection delay initialization.

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -159,7 +159,7 @@ public interface ConnectionFactory {
   HashAlgorithm getHashAlg();
 
   /**
-   * Maximum number of milliseconds to wait between reconnect attempts.
+   * Maximum number of seconds to wait between reconnect attempts.
    */
   long getMaxReconnectDelay();
 

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -259,7 +259,7 @@ public class MemcachedConnection extends SpyThread {
     addedQueue = new ConcurrentLinkedQueue<MemcachedNode>();
     failureMode = fm;
     shouldOptimize = f.shouldOptimize();
-    maxDelay = TimeUnit.SECONDS.toMillis(f.getMaxReconnectDelay());
+    maxDelay = f.getMaxReconnectDelay();
     opFact = opfactory;
     timeoutExceptionThreshold = f.getTimeoutExceptionThreshold();
     selector = Selector.open();


### PR DESCRIPTION
This change fixes the following bug in max reconnect delay initialization:

The 'maxDelay' parameter is used to be set in seconds (but if it was specified in milliseconds, the things would be even worser). Currently, it's transformed during initialization with TimeUnit.SECONDS.toMillis.
It means that the specified value is multiplied by 1000 in constructor.
And then it appears in this code snippet from method 'queueReconnect':

long delay = (long) Math.min(maxDelay, Math.pow(2,
        node.getReconnectCount())) \* 1000;
long reconnectTime = System.currentTimeMillis() + delay;

As you can see, it's multiplied by 1000 second time here, what is obviously causes 1000 times longer delay then the user expects.
