### PR TITLE
Patch for issue 192

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1454,9 +1454,21 @@ public class MemcachedConnection extends SpyThread {
         logRunException(e);
       } catch (ConcurrentModificationException e) {
         logRunException(e);
+      }  catch (Throwable t) {
+        logThrowable(t);
       }
     }
     getLogger().info("Shut down memcached client");
+  }
+
+  private void logThrowable(Throwable t) {
+    if (shutDown) {
+      // There are a couple types of errors that occur during the
+      // shutdown sequence.
+      getLogger().info("Unexpected error occurred during shutdown", t);
+    } else {
+      getLogger().warn("Problem handling memcached IO", t);
+    }
   }
 
   /**


### PR DESCRIPTION
Hi guys,

I push this patch in relation with the issue 192 from google code (https://code.google.com/p/spymemcached/issues/detail?id=192)

The bug date is from 2011 and it's still alive.

This issue caused the dead of the thread which reads in the input queue. An exception is thrown and not caught.
When the thread is dead, the input queue increases and when it's full, we get this exception:

```
Memcached timeout: Timeout waiting for value: waited 1,000 ms. Node status: Connection Status { app11-psw-ser/10.163.195.155:11211 active: true, authed: true, last read: 14,183,852 ms ago app12-psw-ser/10.163.195.156:11211 active: true, authed: true, last read: 14,184,114 ms ago app13-psw-ser/10.163.195.157:11211 active: true, authed: true, last read: 14,184,012 ms ago app14-psw}
```

The application crashes and we have to restart it.

Currently, we have the bug in production once by day or less. After we deployed the patch, we get this exception:

```
2015-01-19 22:07:16.766 WARN net.spy.memcached.MemcachedConnection:  Problem handling memcached IO
java.lang.NullPointerException
```

Not really speaking but the thread doesn't die and the application doesn't crash.
