### PR TITLE
Array based ring, for ketama node locator lookups, for improved performance

### DIFF
--- a/src/main/java/net/spy/memcached/ArrayBasedCeilRing.java
+++ b/src/main/java/net/spy/memcached/ArrayBasedCeilRing.java
@@ -1,0 +1,153 @@
+package net.spy.memcached;
+
+
+
+import java.util.*;
+
+/**
+ * Uses a sorted array of values to represent the consistent hash ring of values that are associated with
+ * memcached nodes are at that index.
+ *
+ * The method {@link #findCeilIndex(long)} finds the index in the array (the memcached node in the ring) at which the
+ * first value is greater than or equal to the given long is.  If the long is greater than the maximum value
+ * in the array then the memcached node at the first position in the array is returned (The first item in the ring)
+ */
+public class ArrayBasedCeilRing {
+
+    private final long[] sortedNodePositions;
+    private final MemcachedNode[] sortedNodes;
+    private final Collection<MemcachedNode> allNodes;
+    private final int lastIndexPosition;
+
+    /**
+     * Is Passed ({@see #nodes}) a map of longs to the associated memcached nodes.
+     * This is used to create the sorted array ring and associated
+     * memcached nodes at those array indexes.
+     *
+     * The {@see #allNodes} is a list of unique memcached nodes that make up the current cluster
+     *
+     * @param nodes A map of longs to memcached nodes that should populate the consistent hash ring.
+     * @param allNodes The unique list of memcached nodes that are represented in the ring.
+     */
+    public ArrayBasedCeilRing(Map<Long, MemcachedNode> nodes, Collection<MemcachedNode> allNodes) {
+        long[] sortedNodePositions = new long[nodes.size()];
+        MemcachedNode[] sortedNodes = new MemcachedNode[nodes.size()];
+        this.allNodes = new ArrayList(allNodes);
+
+        Long[] sortedObjectNodePositions = nodes.keySet().toArray(new Long[nodes.size()]);
+        Arrays.sort(sortedObjectNodePositions);
+
+        int i = 0;
+        for(Long position : sortedObjectNodePositions) {
+            sortedNodePositions[i] = position;
+            sortedNodes[i++] = nodes.get(position);
+        }
+
+        this.sortedNodePositions = sortedNodePositions;
+        this.sortedNodes = sortedNodes;
+        this.lastIndexPosition = nodes.size()-1;
+    }
+
+    /**
+     * Returns the max value in the ring that a memcached node is located at.
+     */
+    public long getMaxPosition() {
+        return sortedNodePositions[lastIndexPosition];
+    }
+
+    /**
+     * Returns as a map, the memcached nodes associated to their positions
+     * @return
+     */
+    public Map<Long,MemcachedNode> asMap() {
+        Map<Long,MemcachedNode> map = new TreeMap<Long,MemcachedNode>();
+        for(int i=0;i<sortedNodePositions.length;i++) {
+            map.put(sortedNodePositions[i],sortedNodes[i]);
+        }
+        return map;
+    }
+
+    /**
+     * Returns the list of memcached nodes that are represented in the current ring.
+     * @return
+     */
+    public Collection<MemcachedNode> getAllNodes() {
+        return allNodes;
+    }
+
+    public ArrayBasedCeilRing roClone() {
+        Map<Long,MemcachedNode> nodes = new HashMap<Long, MemcachedNode>(sortedNodePositions.length,1.0f);
+        for(int i=0;i<sortedNodePositions.length;i++) {
+            nodes.put(sortedNodePositions[i],new MemcachedNodeROImpl(sortedNodes[i]));
+        }
+        List<MemcachedNode> allNodes = new ArrayList<MemcachedNode>(this.allNodes.size());
+        for(MemcachedNode node : this.allNodes) {
+            allNodes.add(new MemcachedNodeROImpl(node));
+        }
+
+        return new ArrayBasedCeilRing(nodes,allNodes);
+    }
+
+    public MemcachedNode findClosestNode(long key) {
+        return sortedNodes[findCeilIndex(key)];
+    }
+
+    /**
+     * Find the index in the array at which the first value greater than or equal
+     * to the given hashVal is.   If hashVal is greater than the maximum value in the
+     * array then 0 is returned (The first item in the ring).  If hashVal is less than or
+     * equal to the first element in the array then 0 is returned (The first item in the ring).
+     *
+     * Uses a binary search type algorithm ( O(log n) ) to find the closest largest value in the array, to the
+     * given hashVal
+     *
+     * @param hashVal The value to find the closest item
+     * @return The index in the array that the closest largest item exists
+     */
+    public int findCeilIndex(final long hashVal) {
+        return findCeilIndex(hashVal,sortedNodePositions,lastIndexPosition);
+    }
+
+    /**
+     * Find the index in the array at which the first value greater than or equal
+     * to the given hashVal is.   If hashVal is greater than the maximum value in the
+     * array then 0 is returned (The first item in the ring).  If hashVal is less than or
+     * equal to the first element in the array then 0 is returned (The first item in the ring).
+     *
+     * Uses a binary search type algorithm ( O(log n) ) to find the closest largest value in the array, to the
+     * given hashVal
+     *
+     * @param hashVal The value to find the closest item
+     * @return The index in the array that the closest largest item exists
+     */
+     static int findCeilIndex(final long hashVal, final long sortedNodePositions[], final int lastIndexPosition) {
+        if (lastIndexPosition < 0) {
+            throw new IllegalArgumentException("array cannot be empty");
+        }
+
+        int low = 0;
+        int high = lastIndexPosition;
+
+        // Check for edge cases
+        if (hashVal > sortedNodePositions[high]) return 0;
+        if (hashVal <= sortedNodePositions[low]) return 0;
+
+
+        while(true) {
+            // div by two
+            int mid = (low + high) >>> 1;
+            long midVal = sortedNodePositions[mid];
+            if (midVal == hashVal) return mid;
+            else if (midVal < hashVal) {
+                low = mid + 1;
+                if (low <= high && sortedNodePositions[low] >= hashVal) return low;
+            }
+            else if (midVal > hashVal) {
+                high = mid - 1;
+                if (high >= low && sortedNodePositions[high] < hashVal) return mid;
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/net/spy/memcached/ArrayBasedCeilRingIterator.java
+++ b/src/main/java/net/spy/memcached/ArrayBasedCeilRingIterator.java
@@ -1,0 +1,61 @@
+package net.spy.memcached;
+
+import java.util.Iterator;
+
+/**
+ * Implements an Iterator which the KetamaNodeLoctaor may return to a client for
+ * iterating through alternate nodes for a given key.
+ */
+public class ArrayBasedCeilRingIterator  implements Iterator<MemcachedNode> {
+
+    private final String key;
+    private long hashVal;
+    private int remainingTries;
+    private int numTries = 0;
+    private final HashAlgorithm hashAlg;
+    private final ArrayBasedCeilRing ring;
+
+    /**
+     * Create a new ArrayBasedCeilRingIterator to be used by a client for an operation.
+     *
+     * @param k the key to iterate for
+     * @param t the number of tries until giving up
+     * @param hashAlg the hash algorithm to use when selecting within the
+     *          continuumq
+     */
+    protected ArrayBasedCeilRingIterator(final String k, final int t,
+                             final HashAlgorithm hashAlg, final ArrayBasedCeilRing ring) {
+        super();
+        this.ring = ring;
+        this.hashAlg = hashAlg;
+        hashVal = hashAlg.hash(k);
+        remainingTries = t;
+        key = k;
+    }
+
+    private void nextHash() {
+        // this.calculateHash(Integer.toString(tries)+key).hashCode();
+        long tmpKey = hashAlg.hash((numTries++) + key);
+        // This echos the implementation of Long.hashCode()
+        hashVal += (int) (tmpKey ^ (tmpKey >>> 32));
+        hashVal &= 0xffffffffL; /* truncate to 32-bits */
+        remainingTries--;
+    }
+
+    public boolean hasNext() {
+        return remainingTries > 0;
+    }
+
+    public MemcachedNode next() {
+        try {
+            return ring.findClosestNode(hashVal);
+        } finally {
+            nextHash();
+        }
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("remove not supported");
+    }
+
+}

--- a/src/test/java/net/spy/memcached/ArrayBasedCeilRingTest.java
+++ b/src/test/java/net/spy/memcached/ArrayBasedCeilRingTest.java
@@ -1,0 +1,359 @@
+package net.spy.memcached;
+
+import junit.framework.TestCase;
+import net.spy.memcached.ops.Operation;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+import java.util.*;
+
+public class ArrayBasedCeilRingTest extends TestCase {
+
+    public void testArrayContainingAllNegatives() throws Exception {
+        long arr[] = new long[] { -5, -3, -1};
+        int lastIndex = arr.length-1;
+
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(9, arr, lastIndex));   // 0
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(11,arr, lastIndex));   // 0
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(Integer.MAX_VALUE, arr,lastIndex));   // 0
+
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(-10,arr,lastIndex));   // 0
+        assertEquals(1,ArrayBasedCeilRing.findCeilIndex(-4,arr,lastIndex));   // 1
+        assertEquals(2,ArrayBasedCeilRing.findCeilIndex(-2,arr,lastIndex));   // 2
+    }
+
+    public void testSingleValueArray() throws Exception {
+        long arr[] = new long[] {10};
+        int lastIndex = arr.length-1;
+
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(9, arr, lastIndex));   // 0
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(11,arr, lastIndex));   // 0
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(Integer.MAX_VALUE, arr,lastIndex));   // 0
+    }
+
+    public void testNegativeToPositiveArray() {
+        // goes from -10000 (in evens) to 9998
+        long arr[] = new long[10000];
+        int j = -10000;
+        for(int i = 0;i<10000;i++) {
+            arr[i] = j + (i * 2);
+
+        }
+
+        int lastIndex = arr.length-1;
+
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(-10000, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(-11000, arr, lastIndex));
+        assertEquals(1,ArrayBasedCeilRing.findCeilIndex(-9999, arr, lastIndex));
+        assertEquals(1,ArrayBasedCeilRing.findCeilIndex(-9998, arr, lastIndex));
+        assertEquals(4,ArrayBasedCeilRing.findCeilIndex(-9993, arr, lastIndex));
+        assertEquals(9999,ArrayBasedCeilRing.findCeilIndex(9998, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(14999, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(14996, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(156674996, arr, lastIndex));
+        assertEquals(6000,ArrayBasedCeilRing.findCeilIndex(2000, arr, lastIndex));
+        assertEquals(5000,ArrayBasedCeilRing.findCeilIndex(0, arr, lastIndex));
+        assertEquals(5001,ArrayBasedCeilRing.findCeilIndex(1, arr, lastIndex));
+        assertEquals(4999,ArrayBasedCeilRing.findCeilIndex(-2, arr, lastIndex));
+        assertEquals(5000,ArrayBasedCeilRing.findCeilIndex(-1, arr, lastIndex));
+        assertEquals(5005,ArrayBasedCeilRing.findCeilIndex(9, arr, lastIndex));
+
+    }
+
+    public void testRandomPositiveArray() {
+        long arr[] = {1, 2, 8, 10, 12, 19, 21, 66, 67, 68, 69, 77, 101};
+        int lastIndex = arr.length-1;
+
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(-1, arr, lastIndex));
+        assertEquals(6,ArrayBasedCeilRing.findCeilIndex(20, arr, lastIndex));
+        assertEquals(5,ArrayBasedCeilRing.findCeilIndex(18, arr, lastIndex));
+        assertEquals(3,ArrayBasedCeilRing.findCeilIndex(9, arr, lastIndex));
+        assertEquals(2,ArrayBasedCeilRing.findCeilIndex(3, arr, lastIndex));
+        assertEquals(2,ArrayBasedCeilRing.findCeilIndex(8, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(1, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(0, arr, lastIndex));
+        assertEquals(5,ArrayBasedCeilRing.findCeilIndex(19, arr, lastIndex));
+        assertEquals(4,ArrayBasedCeilRing.findCeilIndex(11, arr, lastIndex));
+        assertEquals(1,ArrayBasedCeilRing.findCeilIndex(2, arr, lastIndex));
+        assertEquals(5,ArrayBasedCeilRing.findCeilIndex(13, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(Integer.MAX_VALUE, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(Integer.MIN_VALUE, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(1, arr, lastIndex));
+    }
+
+    public void test10000PositiveArray() {
+        long[] arr = new long[10000];
+        for(int i = 0;i<10000;i++) {
+            arr[i] = i*2;
+        }
+        int lastIndex = arr.length-1;
+
+
+        assertEquals(9999,ArrayBasedCeilRing.findCeilIndex(19998, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(19999, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(20000, arr, lastIndex));
+        assertEquals(1000,ArrayBasedCeilRing.findCeilIndex(2000, arr, lastIndex));
+        assertEquals(500,ArrayBasedCeilRing.findCeilIndex(999, arr, lastIndex));
+        assertEquals(500,ArrayBasedCeilRing.findCeilIndex(1000, arr, lastIndex));
+        assertEquals(0,ArrayBasedCeilRing.findCeilIndex(-99, arr, lastIndex));
+    }
+
+    public void testExceptionThrownOnEmptyArray() {
+        long[] arr = new long[0];
+        int lastIndex = arr.length-1;
+
+        try {
+            ArrayBasedCeilRing.findCeilIndex(Integer.MIN_VALUE,arr,lastIndex);
+            fail("IllegalArgumentException expect to be thrown on an empty array");
+        } catch(IllegalArgumentException e) {
+            e.printStackTrace(System.out);
+        }
+    }
+
+
+    public void testEmptyMapThrowsException() {
+        Map<Long,MemcachedNode> nodes = new HashMap<Long,MemcachedNode>();
+        ArrayBasedCeilRing ring = new ArrayBasedCeilRing(nodes, Collections.EMPTY_LIST);
+
+        try {
+            ring.findCeilIndex(0);
+            fail("IllegalArgumentException expect to be thrown on an empty array");
+        } catch(IllegalArgumentException e) {
+            e.printStackTrace(System.out);
+        }
+    }
+
+    public void testMapResultsInCorrectlySortedRing() {
+        Map<Long,MemcachedNode> nodes = new HashMap<Long,MemcachedNode>();
+        List<MemcachedNode> nodesRepresented = new ArrayList(2);
+
+        MemcachedNode node1 = new RingTestingMemcachedNode(1234);
+        MemcachedNode node2 = new RingTestingMemcachedNode(-100234);
+
+        nodesRepresented.add(node1);
+        nodesRepresented.add(node2);
+        // 1, 2, 8, 10, 10, 12, 19, 21, 66, 67 };
+        nodes.put(8l,node1);
+        nodes.put(1l,node1);
+        nodes.put(19l,node1);
+        nodes.put(10l,node1);
+        nodes.put(2l,node2);
+        nodes.put(21l,node2);
+        nodes.put(67l,node2);
+        nodes.put(12l,node2);
+        nodes.put(66l,node2);
+
+
+        ArrayBasedCeilRing ring = new ArrayBasedCeilRing(nodes,nodesRepresented);
+
+        assertEquals(2,ring.getAllNodes().size());
+        assertEquals(67,ring.getMaxPosition());
+
+        assertEquals(1234,ring.findClosestNode(7).lastReadDelta());
+        assertEquals(-100234,ring.findClosestNode(62).lastReadDelta());
+
+
+    }
+
+    class RingTestingMemcachedNode implements MemcachedNode {
+
+
+        private final long lastReadDelta;
+        public RingTestingMemcachedNode(long lastReadDelta) {
+            this.lastReadDelta = lastReadDelta;
+        }
+
+        @Override
+        public void copyInputQueue() {
+
+        }
+
+        @Override
+        public Collection<Operation> destroyInputQueue() {
+            return null;
+        }
+
+        @Override
+        public void setupResend() {
+
+        }
+
+        @Override
+        public void fillWriteBuffer(boolean optimizeGets) {
+
+        }
+
+        @Override
+        public void transitionWriteItem() {
+
+        }
+
+        @Override
+        public Operation getCurrentReadOp() {
+            return null;
+        }
+
+        @Override
+        public Operation removeCurrentReadOp() {
+            return null;
+        }
+
+        @Override
+        public Operation getCurrentWriteOp() {
+            return null;
+        }
+
+        @Override
+        public Operation removeCurrentWriteOp() {
+            return null;
+        }
+
+        @Override
+        public boolean hasReadOp() {
+            return false;
+        }
+
+        @Override
+        public boolean hasWriteOp() {
+            return false;
+        }
+
+        @Override
+        public void addOp(Operation op) {
+
+        }
+
+        @Override
+        public void insertOp(Operation o) {
+
+        }
+
+        @Override
+        public int getSelectionOps() {
+            return 0;
+        }
+
+        @Override
+        public ByteBuffer getRbuf() {
+            return null;
+        }
+
+        @Override
+        public ByteBuffer getWbuf() {
+            return null;
+        }
+
+        @Override
+        public SocketAddress getSocketAddress() {
+            return null;
+        }
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
+
+        @Override
+        public boolean isAuthenticated() {
+            return false;
+        }
+
+        @Override
+        public long lastReadDelta() {
+            return lastReadDelta;
+        }
+
+        @Override
+        public void completedRead() {
+
+        }
+
+        @Override
+        public void reconnecting() {
+
+        }
+
+        @Override
+        public void connected() {
+
+        }
+
+        @Override
+        public int getReconnectCount() {
+            return 0;
+        }
+
+        @Override
+        public void registerChannel(SocketChannel ch, SelectionKey selectionKey) {
+
+        }
+
+        @Override
+        public void setChannel(SocketChannel to) {
+
+        }
+
+        @Override
+        public SocketChannel getChannel() {
+            return null;
+        }
+
+        @Override
+        public void setSk(SelectionKey to) {
+
+        }
+
+        @Override
+        public SelectionKey getSk() {
+            return null;
+        }
+
+        @Override
+        public int getBytesRemainingToWrite() {
+            return 0;
+        }
+
+        @Override
+        public int writeSome() throws IOException {
+            return 0;
+        }
+
+        @Override
+        public void fixupOps() {
+
+        }
+
+        @Override
+        public void authComplete() {
+
+        }
+
+        @Override
+        public void setupForAuth() {
+
+        }
+
+        @Override
+        public void setContinuousTimeout(boolean timedOut) {
+
+        }
+
+        @Override
+        public int getContinuousTimeout() {
+            return 0;
+        }
+
+        @Override
+        public MemcachedConnection getConnection() {
+            return null;
+        }
+
+        @Override
+        public void setConnection(MemcachedConnection connection) {
+
+        }
+    }
+}

--- a/src/test/java/net/spy/memcached/QueueOverflowTest.java
+++ b/src/test/java/net/spy/memcached/QueueOverflowTest.java
@@ -156,7 +156,7 @@ public class QueueOverflowTest extends ClientBaseCase {
         // OK, at least we got one back.
       }
     }
-    Thread.sleep(500);
+    Thread.sleep(5000); // give enough time for the client to reconnect
     assertTrue(client.set("kx", 0, "woo").get(5, TimeUnit.SECONDS));
   }
 }

--- a/src/test/java/net/spy/memcached/internal/DummyListenableFuture.java
+++ b/src/test/java/net/spy/memcached/internal/DummyListenableFuture.java
@@ -38,7 +38,7 @@ public class DummyListenableFuture<T>
   private boolean done;
   private boolean cancelled = false;
 
-  private T content = null;
+  private volatile T content = null;
 
   public DummyListenableFuture(boolean alreadyDone, ExecutorService service) {
     super(service);
@@ -78,8 +78,8 @@ public class DummyListenableFuture<T>
   }
 
   public void set(T c) {
-    notifyListeners();
     content = c;
+    notifyListeners();
   }
 
   @Override


### PR DESCRIPTION
Hi there

This is pull request for changing the KetamaNodeLocator from using a `TreeMap<Long,MemcachedNode>` to than of an array based ring lookup.   

I noticed that the TreeMap implementation has a few performance related issues:

- creation of Long objects (due to autoboxing) as a result of the TreeMap being keyed on Long objects
- lookups on containsKey, get, isEmpty take cpu time.

To avoid the first, whilst improving on 2, I have changed the TreeMap ring implementation to use that of a sorted long[], and implement a binary search for the closest ceil long in the array, against which to hash entries.  This avoids the creation of the Long objects, and also only searches for the closest ceil long in the array the once.

The jmh benchmark is showing this implementation of the ring to be more performant.  

    =======================================
    Original KetamaNodeLocator:
    =======================================

    Benchmark                                   Mode  Cnt  Score   Error   Units
    NodeLocatorPerfTest.testKetemaNodeLocator  thrpt   40  0.599 ± 0.013  ops/ms

    =======================================
    New Array Based Ring KetamaNodeLocator:
    =======================================
    Benchmark                                       Mode  Cnt  Score   Error   Units
    NodeLocatorPerfTest.testCeilingKeyNodeLocator  thrpt   40  1.263 ± 0.032  ops/ms
 

Here is the output from Java Flight Recorder and Mission Control that show the before and after.  With the after now showing that item that impacts performance/takes up CPU to be that of the HashingAlgorithm and not the node lookup in the ring:

Before:

CPU:
![screen shot 2015-08-15 at 14 55 44](https://cloud.githubusercontent.com/assets/211070/9289393/d3c70dd6-4365-11e5-886c-085c151f8fbf.png)
 
Allocations:
![screen shot 2015-08-15 at 14 56 06](https://cloud.githubusercontent.com/assets/211070/9289395/e2a02a7c-4365-11e5-8e1b-720e81f44264.png)


-----

After

CPU (getBytes is from get bytes on the string to byte[] required by the key hashing)
![screen shot 2015-08-15 at 14 57 24](https://cloud.githubusercontent.com/assets/211070/9289398/ef5432a4-4365-11e5-9cb0-59779564f0a3.png)

Memory: (no more Longs)
![screen shot 2015-08-15 at 14 58 00](https://cloud.githubusercontent.com/assets/211070/9289402/0d71c44a-4366-11e5-81e0-c0083a64d7bb.png)


-----

As a side note I have fixed a concurrency issue in the test case: `DummyListenableFuture`.  It was notifying listeners before setting the content.  Also as the listeners are executed on a separate thread, the content needs to be volatile to ensure publication of the value (set in one thread) to the executor thread that the listener is running on.

I also increased the sleep time in `QueueOverflowTest` to allow the client to recover/reconnect as it was always failing, before even these changes were done.  With the increased timeout out the test is working.