### PR TITLE
Defer String Concat in handleEmptySelects()

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -485,8 +485,8 @@ public class MemcachedConnection extends SpyThread {
    * Helper method for {@link #handleIO()} to handle empty select calls.
    */
   private void handleEmptySelects() {
-    getLogger().debug("No selectors ready, interrupted: "
-      + Thread.interrupted());
+    getLogger().debug("No selectors ready, interrupted: %b",
+      Thread.interrupted());
 
     if (++emptySelects > DOUBLE_CHECK_EMPTY) {
       for (SelectionKey sk : selector.keys()) {


### PR DESCRIPTION
MemcachedConnection.handleEmptySelects() has a debug level log
statement that doesn't correctly defer the concatentation of
the argument until it has determined that the level is enabled.