### PR TITLE
HH-69249 add ConnectionFactoryBuilder(ConnectionFactoryBuilder) constructor, deprecate one that accepts ConnectionFactory

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -85,6 +85,36 @@ public class ConnectionFactoryBuilder {
     // empty
   }
 
+  public ConnectionFactoryBuilder(ConnectionFactoryBuilder source) {
+    setOpQueueFactory(source.opQueueFactory);
+    setReadOpQueueFactory(source.readQueueFactory);
+    setWriteOpQueueFactory(source.writeQueueFactory);
+    setTranscoder(source.transcoder);
+    setFailureMode(source.failureMode);
+    setInitialObservers(source.initialObservers);
+    setOpFact(source.opFact);
+    setLocatorType(source.locator);
+    setOpTimeout(source.opTimeout);
+    setDaemon(source.isDaemon);
+    setShouldOptimize(source.shouldOptimize);
+    setUseNagleAlgorithm(source.useNagle);
+    setMaxReconnectDelay(source.maxReconnectDelay);
+    setReadBufferSize(source.readBufSize);
+    setHashAlg(source.hashAlg);
+    setAuthDescriptor(source.authDescriptor);
+    setOpQueueMaxBlockTime(source.opQueueMaxBlockTime);
+    setTimeoutExceptionThreshold(source.timeoutExceptionThreshold);
+    setEnableMetrics(source.metricType);
+    setMetricCollector(source.collector);
+    setListenerExecutorService(source.executorService);
+    setAuthWaitTime(source.authWaitTime);
+  }
+
+  /**
+   * @deprecated because some values (eg. opQueueFactory or locator) can not be easily copied from {@link ConnectionFactory}.<br/>
+   * Use {@link #ConnectionFactoryBuilder(ConnectionFactoryBuilder)} instead.
+   */
+  @Deprecated
   public ConnectionFactoryBuilder(ConnectionFactory cf) {
     setAuthDescriptor(cf.getAuthDescriptor());
     setDaemon(cf.isDaemon());
@@ -270,7 +300,7 @@ public class ConnectionFactoryBuilder {
   public ConnectionFactoryBuilder setTimeoutExceptionThreshold(int to) {
     assert to > 1 : "Minimum timeout exception threshold is 2";
     if (to > 1) {
-      timeoutExceptionThreshold = to - 2;
+      timeoutExceptionThreshold = to;
     }
     return this;
   }


### PR DESCRIPTION
# Problem
Some important settings are not copied from ConnectionFactory to ConnectionFactoryBuilder in the ConnectionFactoryBuilder(ConnectionFactory) constructor.
https://github.com/couchbase/spymemcached/blob/8fe2e33708e2a6e4620a8d7e53a17cb4e7aa2eaf/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java#L88-L105
For example, locator type, protocol or queueFactories.
This results in nasty bugs: we expect ConnectionFactoryBuilder to get the same node locator as in the source ConnectionFactory, but implicilty get default node locator.

# Case
We create two almost identical instances of MemcachedClient (same nodes, same protocol, same queues sizes, etc.), the only difference is operation timeout.
We use low operation timeout (25 ms) if we can tolerate some false positive timeouts, but we do not want to block caller thread for too long in case of troubles with net or a memcached node.
We use higher operation timeout (100 ms) if we can not tolerate false positive timeouts, for example for cache invalidation.
In order to reuse all settings we create highTimeoutConnectionFactoryBuilder using lowTimeoutConnectionFactory.
Unfortunately we are unable to reuse all settings because ConnectionFactoryBuilder(ConnectionFactory) constructor does not copy some important settings: locator type, protocol, queueFactories.

# Possible solution
There is no simple way to copy these missing settings from ConnectionFactory to ConnectionFactoryBuilder, that is why I decided to deprecate this constructor and create new one ConnectionFactoryBuilder(ConnectionFactoryBuilder).
Please, let me know if I should create jira task and rename my branch accordingly.