### PR TITLE
CachedThreadPool's BlockingQueue should be SynchronousQueue

### DIFF
--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -303,7 +303,7 @@ public class DefaultConnectionFactory extends SpyObject implements
         Runtime.getRuntime().availableProcessors(),
         60L,
         TimeUnit.SECONDS,
-        new LinkedBlockingQueue<Runnable>(),
+        new SynchronousQueue<Runnable>(),
         threadFactory
       );
     }


### PR DESCRIPTION
If corePoolSize equals zero, and use LinkedBlockingQueue as BlockingQueue, the threads number here will never reach to Runtime.getRuntime().availableProcessors(), and only create one thread to do the jobs.

See java.util.concurrent.Executors.newCachedThreadPool.

We should use SynchronousQueue instead of LinkedBlockingQueue.