### PR TITLE
Fix ConcurrentModificationException for getStats Op

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1710,18 +1710,20 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
   @Override
   public Map<SocketAddress, Map<String, String>> getStats(final String arg) {
     final Map<SocketAddress, Map<String, String>> rv =
-        new HashMap<SocketAddress, Map<String, String>>();
+        new ConcurrentHashMap<SocketAddress, Map<String, String>>();
 
     CountDownLatch blatch = broadcastOp(new BroadcastOpFactory() {
       @Override
       public Operation newOp(final MemcachedNode n,
           final CountDownLatch latch) {
         final SocketAddress sa = n.getSocketAddress();
-        rv.put(sa, new HashMap<String, String>());
+        rv.put(sa, new HashMap<String, String>(0));
         return opFact.stats(arg, new StatsOperation.Callback() {
+          private final Map<String,String> data =
+              new HashMap<String,String>();
           @Override
           public void gotStat(String name, String val) {
-            rv.get(sa).put(name, val);
+            data.put(name, val);
           }
 
           @Override
@@ -1729,6 +1731,9 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
           public void receivedStatus(OperationStatus status) {
             if (!status.isSuccess()) {
               getLogger().warn("Unsuccessful stat fetch: %s", status);
+            }
+            else {
+              rv.put(sa, data);
             }
           }
 


### PR DESCRIPTION
If the result of MemcachedClient.getStats() is immediately iterated
over, a ConcurrentModificationException can be thrown if the
operationTimeout value has been exceeded before mutations to the
Map have completed.

Example:

* blatch.await(operationTimeout, TimeUnit.MILLISECONDS); returns
  false after waiting `operationTimeout`, resulting in
  MemcachedClient.getStats() returning the `rv` Map.
* While the caller starts to iterate over the Map, the
  StatsOperation.Callback's gotStat mutates the Map, resulting in
  a ConcurrentModificationException.

How to Reproduce:

```
public static void main(String[] args) throws Exception {
  ConnectionFactory connectionFactory = new ConnectionFactoryBuilder()
    .setProtocol(Protocol.TEXT)
    .setFailureMode(FailureMode.Cancel)
    .setOpTimeout(1)
    .build();
  MemcachedClient client = new MemcachedClient(
    connectionFactory, AddrUtil.getAddresses("localhost:11211"));
  while(true) {
    Map<SocketAddress, Map<String, String>> allStats = client.getStats();
    if (allStats.isEmpty()) continue;
    Map<String, String> stats = allStats.entrySet().iterator().next().getValue();
    for(Entry<String,String> stat : stats.entrySet()) {
      System.out.println(stat.getKey() + " => " + stat.getValue());
    }
  }
}
```

Output:

```
2017-11-02 14:37:52.269 WARN net.spy.memcached.MemcachedClient:  Unsuccessful stat fetch: {OperationStatus success=false:  timed out}
Exception in thread "main" java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextEntry(HashMap.java:922)
	at java.util.HashMap$EntryIterator.next(HashMap.java:962)
	at java.util.HashMap$EntryIterator.next(HashMap.java:960)
	at com.xxx.xxx.xxx.xxx.xxx.StatsBug.main(StatsBug.java:31)
  ```

Notes:

* Written in a way to be completely backwards compatible.
* Guarantees that the caller only sees the entire stats result for a
  SocketAddress, or no result at all. Converting the Maps to
  ConcurrentHashMaps alone would result in partially complete
  Maps.