### PR TITLE
Optimize StatusCode Line Matching for ASCII

### DIFF
--- a/src/main/java/net/spy/memcached/ops/StatusCode.java
+++ b/src/main/java/net/spy/memcached/ops/StatusCode.java
@@ -92,7 +92,8 @@ public enum StatusCode {
     } else if (line.equals("NOT_FOUND")) {
       return ERR_NOT_FOUND;
     } else if (line.equals("ERROR")
-      || line.matches("^(CLIENT|SERVER)_ERROR.*")) {
+      || line.startsWith("CLIENT_ERROR")
+      || line.startsWith("SERVER_ERROR")) {
       return ERR_INTERNAL;
     } else {
       return ERR_CLIENT;


### PR DESCRIPTION
String.matches(String regex) results in a re-compilation of the regex
every single invocation. Instead of using an underlying inefficient
Pattern/Matcher, instead use String.startsWith(String prefix). This
optimization matters for high throughput usecases when an endpoint
goes down and the number of SERVER_ERROR spikes dramatically.