### PR TITLE
Optimize AbstractListenableFuture Memory Allocations

### DIFF
--- a/src/main/java/net/spy/memcached/internal/AbstractListenableFuture.java
+++ b/src/main/java/net/spy/memcached/internal/AbstractListenableFuture.java
@@ -141,15 +141,22 @@ public abstract class AbstractListenableFuture
    * @param future the future to pass on to the listeners.
    */
   protected void notifyListeners(final Future<?> future) {
-    final List<GenericCompletionListener<? extends Future<T>>> copy =
-      new ArrayList<GenericCompletionListener<? extends Future<T>>>();
+    final List<GenericCompletionListener<? extends Future<T>>> copy;
     synchronized(this) {
-      copy.addAll(listeners);
+      if (listeners.isEmpty()) {
+        copy = null;
+      }
+      else {
+        copy = new ArrayList<GenericCompletionListener
+          <? extends Future<T>>>(listeners);
+      }
       listeners = new ArrayList<GenericCompletionListener<? extends Future<T>>>();
     }
-    for (GenericCompletionListener<? extends Future<? super T>> listener
-      : copy) {
-      notifyListener(executor(), future, listener);
+    if (copy != null) {
+      for (GenericCompletionListener<? extends Future<? super T>> listener
+        : copy) {
+        notifyListener(executor(), future, listener);
+      }
     }
   }
 


### PR DESCRIPTION
Problem: If an empty ArrayList has addAll() invoked with a Collection
argument that has a size less than 10, the underlying elementData
Object[] is still grown to 10 via an Array copy. In the case of
AbstractListenableFuture, the number of listeners is often 0 or 1,
and AbstractListenableFuture is in the critical path, meaning this
behavior causes unnecessary GC pressure for high throughput
applications.

Therefore, this commit enhances the logic to avoid the construction
of the listener copy ArrayList and its iterator if possible, and if
not, to use the more efficient constructor vs. addAll().