### PR TITLE
Remove VBucket-specific HashSet from BaseOperationImpl

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -26,12 +26,9 @@ package net.spy.memcached.protocol;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.compat.SpyObject;
@@ -66,8 +63,6 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
   private volatile boolean timedout;
   private long creationTime;
   private boolean timedOutUnsent = false;
-  protected Collection<MemcachedNode> notMyVbucketNodes =
-      new HashSet<MemcachedNode>();
   private long writeCompleteTimestamp;
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiKeyOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiKeyOperationImpl.java
@@ -26,6 +26,7 @@ package net.spy.memcached.protocol.binary;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import net.spy.memcached.MemcachedNode;
@@ -40,7 +41,10 @@ import net.spy.memcached.util.StringUtils;
  */
 abstract class MultiKeyOperationImpl extends OperationImpl implements
   VBucketAware, KeyedOperation {
+
   protected final Map<String, Short> vbmap;
+  protected Collection<MemcachedNode> notMyVbucketNodes =
+      new HashSet<MemcachedNode>();
 
   protected MultiKeyOperationImpl(byte c, int o, OperationCallback cb) {
     super(c, o, cb);

--- a/src/main/java/net/spy/memcached/protocol/binary/SingleKeyOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SingleKeyOperationImpl.java
@@ -25,6 +25,7 @@ package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.ops.KeyedOperation;
@@ -39,6 +40,8 @@ abstract class SingleKeyOperationImpl extends OperationImpl implements
     VBucketAware, KeyedOperation {
 
   protected final String key;
+  protected Collection<MemcachedNode> notMyVbucketNodes =
+      new HashSet<MemcachedNode>();
 
   protected SingleKeyOperationImpl(byte c, int o, String k,
       OperationCallback cb) {


### PR DESCRIPTION
The notMyVbucketNodes HashSet in BaseOperationImpl is only used for
Couchbase operations. Given that spymemcached is a memcached client
first and foremost, move notMyVbucketNodes to operation
implementations that actually need it to relieve memory pressure for
high throughput memcached-only applications.