### PR TITLE
Avoid Unnecessary Autoboxing & Allocations

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -40,6 +40,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
   private static final int OVERHEAD = 32;
   private static final OperationStatus STORED = new OperationStatus(true,
       "STORED", StatusCode.SUCCESS);
+  private static final String ZERO = "0";
   protected final String type;
   protected final String key;
   protected final int flags;
@@ -66,9 +67,11 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
 
   @Override
   public void initialize() {
+    byte[] keyBytes = KeyUtil.getKeyBytes(key);
     ByteBuffer bb = ByteBuffer.allocate(data.length
-        + KeyUtil.getKeyBytes(key).length + OVERHEAD);
-    setArguments(bb, type, key, flags, exp, data.length);
+        + keyBytes.length + OVERHEAD);
+    setArgumentsWithKey(bb, type, keyBytes, flags == 0 ? ZERO : flags,
+        exp == 0 ? ZERO : exp, data.length);
     assert bb.remaining() >= data.length + 2 : "Not enough room in buffer,"
         + " need another " + (2 + data.length - bb.remaining());
     bb.put(data);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -49,6 +49,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
       false, "NOT_FOUND", CASResponse.NOT_FOUND, StatusCode.ERR_NOT_FOUND);
   private static final OperationStatus EXISTS = new CASOperationStatus(false,
       "EXISTS", CASResponse.EXISTS, StatusCode.ERR_EXISTS);
+  private static final String ZERO = "0";
 
   private final String key;
   private final long casValue;
@@ -76,9 +77,11 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
 
   @Override
   public void initialize() {
+    byte[] keyBytes = KeyUtil.getKeyBytes(key);
     ByteBuffer bb = ByteBuffer.allocate(data.length
-        + KeyUtil.getKeyBytes(key).length + OVERHEAD);
-    setArguments(bb, "cas", key, flags, exp, data.length, casValue);
+      + keyBytes.length + OVERHEAD);
+    setArgumentsWithKey(bb, "cas", keyBytes, flags == 0 ? ZERO : flags,
+        exp == 0 ? ZERO : exp, data.length, casValue);
     assert bb.remaining() >= data.length + 2 : "Not enough room in buffer,"
         + " need another " + (2 + data.length - bb.remaining());
     bb.put(data);

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -62,9 +62,9 @@ final class DeleteOperationImpl extends OperationImpl implements
 
   @Override
   public void initialize() {
-    ByteBuffer b = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
-        + OVERHEAD);
-    setArguments(b, "delete", key);
+    byte[] keyBytes = KeyUtil.getKeyBytes(key);
+    ByteBuffer b = ByteBuffer.allocate(keyBytes.length + OVERHEAD);
+    setArgumentsWithKey(b, "delete", keyBytes);
     b.flip();
     setBuffer(b);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -72,9 +72,10 @@ final class MutatorOperationImpl extends OperationImpl implements
 
   @Override
   public void initialize() {
-    int size = KeyUtil.getKeyBytes(key).length + OVERHEAD;
+    byte[] keyBytes = KeyUtil.getKeyBytes(key);
+    int size = keyBytes.length + OVERHEAD;
     ByteBuffer b = ByteBuffer.allocate(size);
-    setArguments(b, mutator.name(), key, amount);
+    setArgumentsWithKey(b, mutator.name(), keyBytes, amount);
     b.flip();
     setBuffer(b);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -109,6 +109,19 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
     bb.put(CRLF);
   }
 
+  void setArgumentsWithKey(ByteBuffer bb, String type, byte[] key,
+      Object... args)
+  {
+	bb.put(KeyUtil.getKeyBytes(type));
+	bb.put((byte) ' ');
+	bb.put(key);
+	for (Object o : args) {
+	  bb.put((byte) ' ');
+	  bb.put(KeyUtil.getKeyBytes(String.valueOf(o)));
+	}
+	bb.put(CRLF);
+  }
+
   OperationErrorType classifyError(String line) {
     OperationErrorType rv = null;
     if (line.startsWith("ERROR")) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/UnlockOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/UnlockOperationImpl.java
@@ -67,9 +67,9 @@ final class UnlockOperationImpl extends OperationImpl implements
 
   @Override
   public void initialize() {
-    ByteBuffer b = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
-        + OVERHEAD);
-    setArguments(b, CMD, key, cas);
+    byte[] keyBytes = KeyUtil.getKeyBytes(key);
+    ByteBuffer b = ByteBuffer.allocate(keyBytes.length + OVERHEAD);
+    setArgumentsWithKey(b, CMD, keyBytes, cas);
     b.flip();
     setBuffer(b);
   }


### PR DESCRIPTION
* KeyUtil.getKeyBytes(String) was being called twice for every Key,
  causing unnecessary byte[] allocations.
* flags is more often than not 0, therefore send 0 as a String vs.
  an int to avoid autoboxing the int to an Integer and requiring
  unnecessary String.valueOf(Integer) + Integer.toString()
  allocations.
* exp is commonly 0 (for never expire), and therefore send 0 as a
  String vs. an int to avoid the same issue mentioned above for
  flags.

If flags is 0 and exp is 0, ~10% less garbage is allocated as a
result of this optimization.