### PR TITLE
Support Get And Touch (GATS) for ASCII Protocol

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -81,10 +81,12 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     return new FlushOperationImpl(delay, cb);
   }
 
+  /**
+   * Get And Touch is only supported in memcached 1.5.3 and later.
+   */
   public GetAndTouchOperation getAndTouch(String key, int expiration,
       GetAndTouchOperation.Callback cb) {
-    throw new UnsupportedOperationException("Get and touch is not supported "
-        + "for ASCII protocol");
+    return new GetAndTouchOperationImpl(key, expiration, cb);
   }
 
   public GetOperation get(String key, GetOperation.Callback cb) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -203,11 +203,20 @@ public abstract class BaseGetOpImpl extends OperationImpl {
     size += afterKeyBytesSize();
     ByteBuffer b = ByteBuffer.allocate(size);
     b.put(cmd.getBytes());
-    for (byte[] k : keyBytes) {
-      b.put((byte) ' ');
-      b.put(k);
+    if (cmd.equals("gats")) {
+      afterKeyBytes(b);
+      for (byte[] k : keyBytes) {
+        b.put((byte) ' ');
+        b.put(k);
+      }
     }
-    afterKeyBytes(b);
+    else {
+      for (byte[] k : keyBytes) {
+        b.put((byte) ' ');
+        b.put(k);
+      }
+      afterKeyBytes(b);
+    }
     b.put(RN_BYTES);
     b.flip();
     setBuffer(b);

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAndTouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAndTouchOperationImpl.java
@@ -30,9 +30,20 @@ import net.spy.memcached.ops.GetAndTouchOperation;
 public class GetAndTouchOperationImpl extends BaseGetOpImpl implements
     GetAndTouchOperation {
 
+  private static final String CMD = "gats";
+
+  /**
+   * @deprecated use {@link #GetAndTouchOperationImpl(String, int,
+   *   net.spy.memcached.ops.GetAndTouchOperation.Callback)}
+   */
   public GetAndTouchOperationImpl(String c, int e,
       GetAndTouchOperation.Callback cb, String k) {
     super(c, e, cb, k);
+  }
+
+  public GetAndTouchOperationImpl(String k, int e,
+      GetAndTouchOperation.Callback cb) {
+    super(CMD, e, cb, k);
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/protocol/ascii/AsciiToStringTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/AsciiToStringTest.java
@@ -46,7 +46,7 @@ public class AsciiToStringTest extends TestCase{
   }
 
   public void testGetAndTouch() {
-    (new GetAndTouchOperationImpl("gat", 15, null, "key")).toString();
+    (new GetAndTouchOperationImpl("key", 15, null)).toString();
   }
 
   public void testTouch() {


### PR DESCRIPTION
Adds support for the "gats" command recently introduced in memcached
1.5.3. To avoid causing any interface changes to MemcachedClientIF,
only the single key "gats" scenario is supported. Multi-key and "gat"
(i.e. "gats" with no cas return value) will be included in a
different pull request.

See:

* https://github.com/memcached/memcached/commit/7f4e0246e5c27baa9a7a690e5905f5ee56b80ece
* https://github.com/memcached/memcached/wiki/ReleaseNotes153