### PR TITLE
Fix blind cast to DefaultHashAlgorithm

### DIFF
--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -465,13 +465,13 @@ public class DefaultConnectionFactory extends SpyObject implements
   @Override
   public String toString() {
     return "Failure Mode: " + getFailureMode().name() + ", Hash Algorithm: "
-      + ((DefaultHashAlgorithm)getHashAlg()).name() + " Max Reconnect Delay: "
+      + String.valueOf(getHashAlg()) + ", Max Reconnect Delay: "
       + getMaxReconnectDelay() + ", Max Op Timeout: " + getOperationTimeout()
-      + ", Op Queue Length: " + getOpQueueLen() + ", Op Max Queue Block Time"
+      + ", Op Queue Length: " + getOpQueueLen() + ", Op Max Queue Block Time: "
       + getOpQueueMaxBlockTime() + ", Max Timeout Exception Threshold: "
       + getTimeoutExceptionThreshold() + ", Read Buffer Size: "
       + getReadBufSize() + ", Transcoder: " + getDefaultTranscoder()
-      + ", Operation Factory: " + getOperationFactory() + " isDaemon: "
+      + ", Operation Factory: " + getOperationFactory() + ", isDaemon: "
       + isDaemon() + ", Optimized: " + shouldOptimize() + ", Using Nagle: "
       + useNagleAlgorithm() + ", ConnectionFactory: " + getName();
   }

--- a/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
@@ -52,4 +52,23 @@ public class ConnectionFactoryTest extends TestCase {
     assertEquals(Integer.MAX_VALUE, cf.createReadOperationQueue()
         .remainingCapacity());
   }
+
+  // fix java.lang.ClassCastException in toString when non-default hash algorithm is provided
+  public void testToStringUsingNonDefaultHashAlgorithm() {
+    ConnectionFactory cf = new DefaultConnectionFactory(100, 1024, new HashAlgorithm() {
+        // some non-default hash algorithm
+        public long hash(String k) {
+            return 0;
+        }
+    });
+    // call toString on ConnectionFactory
+    assertTrue(cf.toString().contains("Hash Algorithm:"));
+  }
+
+  public void testToString() {
+    ConnectionFactory cf = new DefaultConnectionFactory();
+    // call toString on ConnectionFactory
+    assertTrue(cf.toString().contains("Hash Algorithm: NATIVE_HASH"));
+  }
+
 }


### PR DESCRIPTION
Using a custom HashAlgorithm causes a ClassCastException when invoking toString on DefaultConnectionFactory. Fix is to use String.valueOf(). Other fixes include adding missing delimiter and white space.