### PR TITLE
Avoid NPE potentially caused by race condition

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -485,8 +485,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject implements
   @Override
   public final String toString() {
     int sops = 0;
-    if (getSk() != null && getSk().isValid()) {
-      sops = getSk().interestOps();
+    final SelectionKey sk = getSk();
+    if (sk != null && sk.isValid()) {
+      sops = sk.interestOps();
     }
     int rsize = readQ.size() + (optimizedOp == null ? 0 : 1);
     int wsize = writeQ.size();


### PR DESCRIPTION
Periodically, we are seeing a `java.lang.NullPointerException` with the following stack trace:

```
…t.spy.memcached.protocol.TCPMemcachedNodeImpl.toString (TCPMemcachedNodeImpl.java:488)
java.util.Formatter$FormatSpecifier.printString (Formatter.java:2886)
java.util.Formatter$FormatSpecifier.print (Formatter.java:2763)
java.util.Formatter.format (Formatter.java:2520)
java.util.Formatter.format (Formatter.java:2455)
java.lang.String.format (String.java:2940)
net.spy.memcached.compat.log.AbstractLogger.info (AbstractLogger.java:161)
net.spy.memcached.MemcachedConnection.handleIO (MemcachedConnection.java:716)
net.spy.memcached.MemcachedConnection.handleIO (MemcachedConnection.java:450)
net.spy.memcached.MemcachedConnection.run (MemcachedConnection.java:1457)
```

As far as I can tell, there must be some sort of race going on where the second call to `getSk()` returns `null` even after the first check passes, causing the de-reference of the `isValid()` method to throw the NPE.  I am wondering if the real fix is to put some sort of lock around the SK or have the getSk() method return a copy to avoid this issue.  It's unclear what the impact is when this happens, but I suspect it is causing an operation to fail/not be executed because the runtime exception.