### PR TITLE
Fix: NPE in fillWriteBuffer

### DIFF
--- a/src/main/java/net/spy/memcached/FillWriteBufferStatus.java
+++ b/src/main/java/net/spy/memcached/FillWriteBufferStatus.java
@@ -1,0 +1,77 @@
+/**
+ * (c) Copyright 2019 freiheit.com technologies GmbH
+ *
+ * Created on 2019-09-26 by Marco Kortkamp (marco.kortkamp@freiheit.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached;
+
+import net.spy.memcached.ops.OperationState;
+
+/**
+ * Status, which tells if a fillWriteBuffer method has
+ * successfully been completed or not.
+ *
+ * @author Marco Kortkamp (marco.kortkamp@freiheit.com)
+ */
+public enum FillWriteBufferStatus {
+    SUCCESS,
+    /**
+     * An operation may be marked as canceled (by an async callback),
+     * before a fillWriteBuffer completed successfully.
+     * <p>
+     * This has been observed, if a large values are written in
+     * a very high frequency to the memcached and the payload contains
+     * the error-code ERR_2BIG.
+     * <p>
+     * @see <a href="https://github.com/couchbase/spymemcached/pull/17/commits/d29fea258f6595922b19667efd39a41611d0c0ec">Bug-Report</a>
+     */
+    OP_STATUS_IS_COMPLETED,
+    /**
+     * The residual entries are just for paranoia. If the operation
+     * state can switch to completed, it might switch to another state
+     * as well. Although this has not been observed jet TBMK.
+     */
+    OP_STATUS_IS_WRITE_QUEUED,
+    OP_STATUS_IS_READING,
+    OP_STATUS_IS_RETRY
+    ;
+
+    public static FillWriteBufferStatus forOperationState(final OperationState opState) {
+        switch (opState){
+            case WRITE_QUEUED:
+                return OP_STATUS_IS_WRITE_QUEUED;
+            case WRITING:
+                return SUCCESS;
+            case READING:
+                return OP_STATUS_IS_READING;
+            case COMPLETE:
+                return OP_STATUS_IS_COMPLETED;
+            case RETRY:
+                return OP_STATUS_IS_RETRY;
+        }
+        return null;
+    }
+
+    public boolean isSuccess() {
+        return this == SUCCESS;
+    }
+}

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -57,17 +57,18 @@ public interface MemcachedNode {
   void setupResend();
 
   /**
+   * Transition the current write item into a read state.
+   */
+  void transitionWriteItem();
+
+  /**
    * Fill the write buffer with data from the next operations in the queue.
    *
    * @param optimizeGets if true, combine sequential gets into a single
    *          multi-key get
+   * @return FillWriteBufferStatus indicates, whether this method was completed successfully or not.
    */
-  void fillWriteBuffer(boolean optimizeGets);
-
-  /**
-   * Transition the current write item into a read state.
-   */
-  void transitionWriteItem();
+  FillWriteBufferStatus fillWriteBuffer(boolean optimizeGets);
 
   /**
    * Get the operation at the top of the queue that is requiring input.

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -62,7 +62,7 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public void fillWriteBuffer(boolean optimizeGets) {
+  public FillWriteBufferStatus fillWriteBuffer(boolean optimizeGets) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -209,9 +209,16 @@ public  abstract class OperationImpl extends BaseOperationImpl
         && !getState().equals(OperationState.COMPLETE)) {
       transitionState(OperationState.RETRY);
     } else {
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      setOpStateAndTriggerCallback(status, errorCode);
     }
+  }
+
+  private void setOpStateAndTriggerCallback(final OperationStatus status, final int errorCode) {
+    if (getLogger().isTraceEnabled()) {
+      getLogger().trace("Received error-code: " + errorCode);
+    }
+    transitionState(OperationState.COMPLETE);
+    getCallback().receivedStatus(status);
   }
 
   /**

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -79,8 +79,8 @@ public class MockMemcachedNode implements MemcachedNode {
     // noop
   }
 
-  public void fillWriteBuffer(boolean optimizeGets) {
-    // noop
+  public FillWriteBufferStatus fillWriteBuffer(boolean optimizeGets) {
+    return null;
   }
 
   public void transitionWriteItem() {

--- a/src/test/manual/net/spy/memcached/test/FillWriteBufferNPETest.java
+++ b/src/test/manual/net/spy/memcached/test/FillWriteBufferNPETest.java
@@ -1,0 +1,87 @@
+/**
+ * (c) Copyright 2019 freiheit.com technologies GmbH
+ *
+ * Created on 2019-09-25 by Marco Kortkamp (marco.kortkamp@freiheit.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached.test;
+
+import net.spy.memcached.BinaryConnectionFactory;
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+
+/**
+ * A manual test which tries to trigger a NPE in the fillWriteBuffer
+ * method, when large session passed to the memcached with very high
+ * frequency.
+ *
+ * The initial verison of this test was provided in the following bug report.
+ * @see <a href="https://github.com/couchbase/spymemcached/pull/17/commits/d29fea258f6595922b19667efd39a41611d0c0ec">Bug Report</a>
+ *
+ * @author Marco Kortkamp (marco.kortkamp@freiheit.com)
+ */
+public class FillWriteBufferNPETest {
+    private static final String MEMCACHED_HOST = "localhost";
+    private static final int MEMCACHED_PORT = 11211;
+    private static final int SLEEP_MS = 1;
+
+    /**
+     * In order to run this test you need a memcached instance.
+     * It can e.g. be started by:
+     *     $ memcached -d -p 11211 -u memcached -m 64 -c 1024
+     *
+     * Experiments were conducted with the VM-Options "-Xmx4G".
+     */
+    public static void main(final String[] args) throws IOException, InterruptedException {
+        final MemcachedClient client = new MemcachedClient(new BinaryConnectionFactory(),
+                Collections.singletonList(new InetSocketAddress(MEMCACHED_HOST, MEMCACHED_PORT))
+        );
+
+        final SerializingTranscoder transcoder  = new SerializingTranscoder();
+        transcoder.setCompressionThreshold(Integer.MAX_VALUE);
+
+        final byte[] data = new byte[2 * 1024 * 1024];
+        int i = 0;
+        try {
+            while (true) {
+                client.set("test", 60, data, transcoder);
+                /*
+                 * If this sleep is not in, the memcached ocassionally closes
+                 * the socket with "java.io.IOException: Connection reset by peer"
+                 * and during the reconnect phase the while loop shovels us into
+                 * a an "java.lang.OutOfMemoryError: Java heap space".
+                 * I'm not sure if this is a remaining issue.
+                 */
+                Thread.sleep(SLEEP_MS);
+                if (i > 0 && i % 100 == 0) {
+                    System.out.println(i);
+                }
+                i++;
+            }
+        } catch (final Throwable t) {
+            t.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This changeset fixes a `NullPointerException` (`NPE`) in the `fillWriteBuffer` mehtod.

The `NPE` can occur, if a an operation is transitioned prematurely into the state `OperationState.COMPLETED`, due to an payload error-code `ERR_2BIG`.

The situation can be reproduced with a `while(true)` loop, which tries to store too large objects in  memcached.

The original reproduction method and the issue description were reported in:
 #17 

Also duplicate successively calls to getters in the `fillWriteBuffer` and the `toString` method have been replaced with a single getter call, because of the danger of race conditions.