### PR TITLE
Fixed BulkGetFuture.get() API to honor operationTimeout.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1319,7 +1319,7 @@ public class MemcachedClient extends SpyObject implements MemcachedClientIF,
     int initialLatchCount = chunks.isEmpty() ? 0 : 1;
     final CountDownLatch latch = new CountDownLatch(initialLatchCount);
     final Collection<Operation> ops = new ArrayList<Operation>(chunks.size());
-    final BulkGetFuture<T> rv = new BulkGetFuture<T>(m, ops, latch, executorService);
+    final BulkGetFuture<T> rv = new BulkGetFuture<T>(m, ops, latch, operationTimeout, executorService);
 
     GetOperation.Callback cb = new GetOperation.Callback() {
       @Override

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -56,16 +56,18 @@ public class BulkGetFuture<T>
   private final Map<String, Future<T>> rvMap;
   private final Collection<Operation> ops;
   private final CountDownLatch latch;
+  private final long defaultTimeoutMillis;
   private OperationStatus status;
   private boolean cancelled = false;
   private boolean timeout = false;
 
   public BulkGetFuture(Map<String, Future<T>> m, Collection<Operation> getOps,
-      CountDownLatch l, ExecutorService service) {
+      CountDownLatch l, long defaultTimeoutMillis, ExecutorService service) {
     super(service);
     rvMap = m;
     ops = getOps;
     latch = l;
+    this.defaultTimeoutMillis = defaultTimeoutMillis;
     status = null;
   }
 
@@ -86,9 +88,9 @@ public class BulkGetFuture<T>
 
   public Map<String, T> get() throws InterruptedException, ExecutionException {
     try {
-      return get(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+      return get(defaultTimeoutMillis, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      throw new RuntimeException("Timed out waiting forever", e);
+      throw new ExecutionException("Bulk operation timed out after " + defaultTimeoutMillis + " millis", e);
     }
   }
 


### PR DESCRIPTION
Fixed BulkGetFuture.get() API to honor operationTimeout instead of waiting forever. This also makes it consistent with single operation GetFuture class - both will use the same operation timeout by default.

This commit fixes the problem in the enterprise environments when asyncBulkGet() API is called:

    client.asyncGetBulk(keys).get();

When multiple shards are used and one of them goes down without closing the connection gracefully, the above call will wait forever on the failed shard. The fix is to modify default BulkFuture.get() behavior to use operationTimeout instead of eternal wait. If a longer wait is required for bulk requests, the timeout can still be provided in the BulkFuture.get(timeout, timeoutUnit) API call.